### PR TITLE
Ignore Graylog meta data

### DIFF
--- a/src/main/java/org/graylog/plugins/map/geoip/GeoIpResolverEngine.java
+++ b/src/main/java/org/graylog/plugins/map/geoip/GeoIpResolverEngine.java
@@ -44,6 +44,7 @@ public class GeoIpResolverEngine {
     private final Timer resolveTime;
     private DatabaseReader databaseReader;
     private boolean enabled;
+    private final String GRAYLOG_PREFIX = "gl2_";
 
 
     public GeoIpResolverEngine(GeoIpResolverConfig config, MetricRegistry metricRegistry) {
@@ -70,12 +71,14 @@ public class GeoIpResolverEngine {
         }
 
         for (Map.Entry<String, Object> field : message.getFields().entrySet()) {
-            String key = field.getKey() + "_geolocation";
-            final List coordinates = extractGeoLocationInformation(field.getValue());
-            if (coordinates.size() == 2) {
-                // We will store the coordinates as a "lat,long" string
-                final String stringGeoPoint = coordinates.get(1) + "," + coordinates.get(0);
-                message.addField(key, stringGeoPoint);
+            if (!field.getKey().startsWith(GRAYLOG_PREFIX)) {
+                String key = field.getKey() + "_geolocation";
+                final List coordinates = extractGeoLocationInformation(field.getValue());
+                if (coordinates.size() == 2) {
+                    // We will store the coordinates as a "lat,long" string
+                    final String stringGeoPoint = coordinates.get(1) + "," + coordinates.get(0);
+                    message.addField(key, stringGeoPoint);
+                }
             }
         }
 

--- a/src/test/java/org/graylog/plugins/map/geoip/GeoIpResolverEngineTest.java
+++ b/src/test/java/org/graylog/plugins/map/geoip/GeoIpResolverEngineTest.java
@@ -85,6 +85,22 @@ public class GeoIpResolverEngineTest {
     }
 
     @Test
+    public void doNotExtractGraylogData() throws Exception {
+        final GeoIpResolverEngine resolver = new GeoIpResolverEngine(config.toBuilder().enabled(false).build(), metricRegistry);
+
+        final Map<String, Object> messageFields = Maps.newHashMap();
+        messageFields.put("_id", (new UUID()).toString());
+        messageFields.put("gl2_source_node", "8.8.8.8");
+
+        final Message message = new Message(messageFields);
+        final boolean filtered = resolver.filter(message);
+
+        assertFalse(filtered, "Message should not be filtered out");
+        assertNull(message.getField("gl2_source_node_geolocation"), "Should not resolve and expose Graylog meta data");
+
+    }
+
+    @Test
     public void extractGeoLocationInformation() throws Exception {
         final GeoIpResolverEngine resolver = new GeoIpResolverEngine(config, metricRegistry);
 


### PR DESCRIPTION
**gl2_source_node** can be a public IP and so is being also translated to a **gl2_source_node_geolocation**.

As gl2_source_node_geolocation is not hidden by web interface and information not really useful, this PR ignore any graylog meta data found in message.