### PR TITLE
Mini improvement to save a string concatenation

### DIFF
--- a/src/main/java/org/graylog/plugins/map/geoip/GeoIpResolverEngine.java
+++ b/src/main/java/org/graylog/plugins/map/geoip/GeoIpResolverEngine.java
@@ -73,10 +73,9 @@ public class GeoIpResolverEngine {
         for (Map.Entry<String, Object> field : message.getFields().entrySet()) {
             final String key = field.getKey();
             if (!key.startsWith(INTERNAL_FIELD_PREFIX)) {
-                final String geoLocationKey = key + "_geolocation";
                 final Optional<Coordinates> coordinates = extractGeoLocationInformation(field.getValue());
                 // We will store the coordinates as a "lat,long" string
-                coordinates.ifPresent(c -> message.addField(geoLocationKey, c.latitude() + "," + c.longitude()));
+                coordinates.ifPresent(c -> message.addField(key + "_geolocation", c.latitude() + "," + c.longitude()));
             }
         }
 


### PR DESCRIPTION
Only build a coordinate field key if there are actual coordinates to be added to the message and avoid it for fields that are not IP addresses or did not resolve to coordinates. Saves us one string concatenation (sometimes) and maybe the world (probably not).

I came across this when looking something else up and thought I'd boy scout for once in a while.