### PR TITLE
Better default path for the geo database

### DIFF
--- a/src/main/java/org/graylog/plugins/map/config/GeoIpResolverConfig.java
+++ b/src/main/java/org/graylog/plugins/map/config/GeoIpResolverConfig.java
@@ -54,7 +54,7 @@ public abstract class GeoIpResolverConfig {
        return builder()
                .enabled(false)
                .dbType(DatabaseType.MAXMIND_CITY)
-               .dbPath("/tmp/GeoLite2-City.mmdb")
+               .dbPath("/etc/graylog/server/GeoLite2-City.mmdb")
                .build();
     }
 

--- a/src/web/components/GeoIpResolverConfig.jsx
+++ b/src/web/components/GeoIpResolverConfig.jsx
@@ -15,7 +15,7 @@ const GeoIpResolverConfig = React.createClass({
       config: {
         enabled: false,
         db_type: 'MAXMIND_CITY',
-        db_path: '/tmp/GeoLite2-City.mmdb',
+        db_path: '/etc/graylog/server/GeoLite2-City.mmdb',
         run_before_extractors: false,
       },
     };


### PR DESCRIPTION
The previous path in /tmp is problematic because that directory is cleaned up on reboot in most Linux distributions.

Refs #23