### PR TITLE
Enrich messages with country code and city name

### DIFF
--- a/src/test/java/org/graylog/plugins/map/geoip/GeoIpResolverEngineTest.java
+++ b/src/test/java/org/graylog/plugins/map/geoip/GeoIpResolverEngineTest.java
@@ -142,7 +142,6 @@ public class GeoIpResolverEngineTest {
         final boolean filtered = resolver.filter(message);
 
         assertFalse(filtered, "Message should not be filtered out");
-        assertEquals(message.getFields().size(), messageFields.size() + 2*3, "Filter should add new message fields");
         assertEquals(metricRegistry.timer(name(GeoIpResolverEngine.class, "resolveTime")).getCount(), 3, "Should have looked up three IPs");
         assertFieldNotResolved(message, "source", "Should not have resolved private IP");
         assertFieldNotResolved(message, "message", "Should have resolved public IP");

--- a/src/test/java/org/graylog/plugins/map/geoip/GeoIpResolverEngineTest.java
+++ b/src/test/java/org/graylog/plugins/map/geoip/GeoIpResolverEngineTest.java
@@ -112,6 +112,20 @@ public class GeoIpResolverEngineTest {
         assertEquals(message.getFields().size(), messageFields.size(), "Filter should not add new message fields");
     }
 
+    private void assertFieldNotResolved(Message message, String fieldName, String errorMessage) {
+        assertNull(message.getField(fieldName + "_geolocation"), errorMessage + " coordinates in " + fieldName);
+        assertNull(message.getField(fieldName + "_country_code"), errorMessage + " country in " + fieldName);
+        assertNull(message.getField(fieldName + "_city_name"), errorMessage + " city in " + fieldName);
+    }
+
+    private void assertFieldResolved(Message message, String fieldName, String errorMessage) {
+        assertNotNull(message.getField(fieldName + "_geolocation"), errorMessage + " coordinates in " + fieldName);
+        assertNotNull(message.getField(fieldName + "_country_code"), errorMessage + " country in " + fieldName);
+        assertNotNull(message.getField(fieldName + "_city_name"), errorMessage + " city in " + fieldName);
+        assertTrue(((String) message.getField(fieldName + "_geolocation")).contains(","),
+                "Location coordinates for " + fieldName + " should include a comma");
+    }
+
     @Test
     public void filterResolvesIpGeoLocation() throws Exception {
         final GeoIpResolverEngine resolver = new GeoIpResolverEngine(config, metricRegistry);
@@ -128,14 +142,12 @@ public class GeoIpResolverEngineTest {
         final boolean filtered = resolver.filter(message);
 
         assertFalse(filtered, "Message should not be filtered out");
-        assertEquals(message.getFields().size(), messageFields.size() + 2, "Filter should add new message fields");
+        assertEquals(message.getFields().size(), messageFields.size() + 2*3, "Filter should add new message fields");
         assertEquals(metricRegistry.timer(name(GeoIpResolverEngine.class, "resolveTime")).getCount(), 3, "Should have looked up three IPs");
-        assertNull(message.getField("source_geolocation"), "Should not have resolved private IP");
-        assertNull(message.getField("message_geolocation"), "Should have resolved public IP inside message");
-        assertNull(message.getField("gl2_remote_ip_geolocation"), "Should not have resolved internal message field");
-        assertNotNull(message.getField("extracted_ip_geolocation"), "Should have resolved public IP inside extracted_ip");
-        assertTrue(((String) message.getField("extracted_ip_geolocation")).contains(","), "Should include a comma");
-        assertNotNull(message.getField("ipv6_geolocation"), "Should have resolved public IPv6 inside ipv6");
-        assertTrue(((String) message.getField("ipv6_geolocation")).contains(","), "Should include a comma");
+        assertFieldNotResolved(message, "source", "Should not have resolved private IP");
+        assertFieldNotResolved(message, "message", "Should have resolved public IP");
+        assertFieldNotResolved(message, "gl2_remote_ip", "Should not have resolved text with an IP");
+        assertFieldResolved(message, "extracted_ip", "Should have resolved public IP");
+        assertFieldResolved(message, "ipv6", "Should have resolved public IPv6");
     }
 }

--- a/src/web/components/GeoIpResolverConfig.jsx
+++ b/src/web/components/GeoIpResolverConfig.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Input, Button } from 'react-bootstrap';
 import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
 import { IfPermitted, Select } from 'components/common';
+import { DocumentationLink } from 'components/support';
 import ObjectUtils from 'util/ObjectUtils';
 
 const GeoIpResolverConfig = React.createClass({
@@ -91,9 +92,9 @@ const GeoIpResolverConfig = React.createClass({
         <h3>Geo-Location Processor</h3>
 
         <p>
-          If enabled, the Geo-Location Processor plugin scans all messages for fields
-          containing <strong>exclusively</strong> an IP address, and puts their geo-location information into a field
-          named <code>fieldname_geolocation</code> where "fieldname" is the name of the field containing an IP address.
+          The Geo-Location Processor plugin scans all messages for fields containing <strong>exclusively</strong> an
+          IP address, and puts their geo-location information (coordinates, ISO country code, and city name) into
+          different fields. Read more in the <DocumentationLink page="geolocation.html" text="Graylog documentation" />.
         </p>
 
         <dl className="deflist">


### PR DESCRIPTION
As #15 is stalled for a while now, I took some time to work on #10 and get this done.

The changes here add the ISO country code (`<fieldname>_country_code`) and the city name (`<fieldname>_city_name`) to those fields that include an IP address with geo-location information. If, for some reason, the country or city information is not available, it will add `N/A` as value for the fields, being able to identify IPs without country or city information easily if using quick values.