### PR TITLE
Upgrade to react-bootstrap 0.30

### DIFF
--- a/src/web/components/GeoIpResolverConfig.jsx
+++ b/src/web/components/GeoIpResolverConfig.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Input, Button } from 'react-bootstrap';
-import BootstrapModalForm from 'components/bootstrap/BootstrapModalForm';
+import { Button } from 'react-bootstrap';
+import { BootstrapModalForm, Input } from 'components/bootstrap';
 import { IfPermitted, Select } from 'components/common';
 import { DocumentationLink } from 'components/support';
 import ObjectUtils from 'util/ObjectUtils';


### PR DESCRIPTION
Use the Input adaptor to display the inputs used in the plugin configuration.

Needs to be built against https://github.com/Graylog2/graylog2-server/pull/3598