### PR TITLE
Revert "Revert "Use `tookMs()` instead of `took().millis()`." (#44)"

### DIFF
--- a/src/main/java/org/graylog/plugins/map/search/MapDataSearch.java
+++ b/src/main/java/org/graylog/plugins/map/search/MapDataSearch.java
@@ -51,7 +51,7 @@ public class MapDataSearch {
             final org.graylog2.indexer.results.TermsResult terms = searches.terms(field, request.limit(), request.query(), filter, request.timerange());
             // TODO: Validate data!
             final Map<String, Long> validatedTerms = validateTerms(field, terms.getTerms());
-            final TermsResult result = TermsResult.create(terms.took().millis(), validatedTerms, terms.getMissing(), terms.getOther(), terms.getTotal(), terms.getBuiltQuery());
+            final TermsResult result = TermsResult.create(terms.tookMs(), validatedTerms, terms.getMissing(), terms.getOther(), terms.getTotal(), terms.getBuiltQuery());
             termResults.put(field, result);
         }
 

--- a/src/main/java/org/graylog/plugins/map/widget/strategy/MapWidgetStrategy.java
+++ b/src/main/java/org/graylog/plugins/map/widget/strategy/MapWidgetStrategy.java
@@ -63,6 +63,6 @@ public class MapWidgetStrategy implements WidgetStrategy {
         result.put("other", terms.getOther());
         result.put("missing", terms.getMissing());
 
-        return new ComputationResult(result, terms.took().millis());
+        return new ComputationResult(result, terms.tookMs());
     }
 }


### PR DESCRIPTION
Reverting the reverted commit now that the `es-http-client` branch is
hitting `master`. (See Graylog2/graylog2-server#3798)

This reverts commit 0ab7e7927732e10a6df8651e4bd15cab870e6940.