### PR TITLE
Map rendering and style improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   "author": "Graylog, Inc. <hello@graylog.com>",
   "license": "GPL-3.0",
   "dependencies": {
-    "leaflet": "~0.7.7",
-    "react-leaflet": "~0.10.0"
+    "leaflet": "^1.2.0",
+    "react-leaflet": "^1.6.0"
   },
   "devDependencies": {
     "graylog-web-plugin": "file:../graylog2-server/graylog2-web-interface/packages/graylog-web-plugin"

--- a/src/web/components/MapVisualization.css
+++ b/src/web/components/MapVisualization.css
@@ -5,6 +5,7 @@
 @media print {
     :local(.map) {
         margin: 0 auto;
+        page-break-inside: avoid;
     }
 
     /* Hide zoom controls */

--- a/src/web/components/MapVisualization.css
+++ b/src/web/components/MapVisualization.css
@@ -1,3 +1,12 @@
+:local(.overlay) {
+    position: absolute;
+    z-index: 1000;
+}
+
+:local(.mapLocked) .leaflet-control-container {
+    display: none;
+}
+
 .leaflet-top, .leaflet-bottom {
     z-index: 999; /* So it displays below bootstrap dropdowns */
 }

--- a/src/web/components/MapVisualization.css
+++ b/src/web/components/MapVisualization.css
@@ -1,3 +1,14 @@
 .leaflet-top, .leaflet-bottom {
     z-index: 999; /* So it displays below bootstrap dropdowns */
 }
+
+@media print {
+    :local(.map) {
+        margin: 0 auto;
+    }
+
+    /* Hide zoom controls */
+    .leaflet-control-container {
+        display: none;
+    }
+}

--- a/src/web/components/MapVisualization.jsx
+++ b/src/web/components/MapVisualization.jsx
@@ -30,11 +30,31 @@ const MapVisualization = React.createClass({
     };
   },
 
+  componentDidMount() {
+    this._forceMapUpdate();
+  },
+
+  componentDidUpdate(prevProps) {
+    if (this.props.height !== prevProps.height || this.props.width !== prevProps.width) {
+      this._forceMapUpdate();
+    }
+  },
+
+  _map: undefined,
   position: [0, 0],
   DEFAULT_URL: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
   DEFAULT_ATTRIBUTION: '&copy; <a href="http://osm.org/copyright" target="_blank">OpenStreetMap</a> contributors',
   MARKER_RADIUS_SIZES: 10,
   MARKER_RADIUS_INCREMENT_SIZES: 10,
+
+  // Workaround to avoid wrong placed markers or empty tiles if the map container size changed.
+  _forceMapUpdate() {
+    if (this._map) {
+      this._map.leafletElement.invalidateSize();
+      window.dispatchEvent(new Event('resize'));
+    }
+  },
+
   // Coordinates are given as "lat,long"
   _formatMarker(coordinates, occurrences, min, max, increment) {
     const formattedCoordinates = coordinates.split(',').map(component => Number(component));

--- a/src/web/components/MapVisualization.jsx
+++ b/src/web/components/MapVisualization.jsx
@@ -44,6 +44,8 @@ const MapVisualization = React.createClass({
   },
 
   _map: undefined,
+  _isMapReady: false,
+  _areTilesReady: false,
   position: [0, 0],
   MARKER_RADIUS_SIZES: 10,
   MARKER_RADIUS_INCREMENT_SIZES: 10,
@@ -86,8 +88,24 @@ const MapVisualization = React.createClass({
     return bucket + increment;
   },
 
+  _handleRenderComplete() {
+    if (this._areTilesReady && this._isMapReady) {
+      this.props.onRenderComplete();
+    }
+  },
+
+  _handleMapReady() {
+    this._isMapReady = true;
+    this._handleRenderComplete();
+  },
+
+  _handleTilesReady() {
+    this._areTilesReady = true;
+    this._handleRenderComplete();
+  },
+
   render() {
-    const { data, id, height, width, url, attribution, interactive, onRenderComplete } = this.props;
+    const { data, id, height, width, url, attribution, interactive } = this.props;
 
     const terms = data.terms;
     const occurrences = Object.keys(terms).map(k => terms[k]);
@@ -108,8 +126,11 @@ const MapVisualization = React.createClass({
            style={{ height: height, width: width }}
            scrollWheelZoom={false}
            animate={interactive}
-           whenReady={onRenderComplete}>
-        <TileLayer url={url} maxZoom={19} attribution={attribution} />
+           zoomAnimation={interactive}
+           fadeAnimation={interactive}
+           markerZoomAnimation={interactive}
+           whenReady={this._handleMapReady}>
+        <TileLayer url={url} maxZoom={19} attribution={attribution} onLoad={this._handleTilesReady} />
         {markers}
       </Map>
     );

--- a/src/web/components/MapVisualization.jsx
+++ b/src/web/components/MapVisualization.jsx
@@ -33,10 +33,6 @@ const MapVisualization = React.createClass({
     };
   },
 
-  componentDidMount() {
-    this._forceMapUpdate();
-  },
-
   componentDidUpdate(prevProps) {
     if (this.props.height !== prevProps.height || this.props.width !== prevProps.width) {
       this._forceMapUpdate();
@@ -53,8 +49,8 @@ const MapVisualization = React.createClass({
   // Workaround to avoid wrong placed markers or empty tiles if the map container size changed.
   _forceMapUpdate() {
     if (this._map) {
-      this._map.leafletElement.invalidateSize();
       window.dispatchEvent(new Event('resize'));
+      this._map.leafletElement.invalidateSize(this.props.interactive);
     }
   },
 

--- a/src/web/components/MapVisualization.jsx
+++ b/src/web/components/MapVisualization.jsx
@@ -14,10 +14,14 @@ const MapVisualization = React.createClass({
     width: PropTypes.number,
     url: PropTypes.string,
     attribution: PropTypes.string,
+    interactive: PropTypes.bool,
+    onRenderComplete: PropTypes.func,
   },
   getDefaultProps() {
     return {
       data: {},
+      interactive: true,
+      onRenderComplete: () => {},
     };
   },
   getInitialState() {
@@ -49,7 +53,7 @@ const MapVisualization = React.createClass({
     );
   },
   _onZoomChange(event) {
-    this.setState({zoomLevel: event.target.getZoom()});
+    this.setState({ zoomLevel: event.target.getZoom() });
   },
   _getBucket(value, bucketCount, minValue, maxValue, increment) {
     // Calculate bucket size based on min/max value and the number of buckets.
@@ -59,24 +63,25 @@ const MapVisualization = React.createClass({
 
     return bucket + increment;
   },
-  render() {
 
-    const data = this.props.data.terms;
-    const occurrences = Object.keys(data).map((k) => data[k]);
+  render() {
+    const { data, id, height, width, url, attribution, interactive, onRenderComplete } = this.props;
+
+    const terms = data.terms;
+    const occurrences = Object.keys(terms).map(k => terms[k]);
     const minOccurrences = occurrences.reduce((prev, cur) => Math.min(prev, cur), Infinity);
     const maxOccurrences = occurrences.reduce((prev, cur) => Math.max(prev, cur), -Infinity);
     const increment = this._getBucket(this.state.zoomLevel, this.MARKER_RADIUS_INCREMENT_SIZES, 1, 10, 1);
 
-    const coordinates = Object.keys(data);
-    const markers = coordinates.map(aCoordinates => this._formatMarker(aCoordinates, data[aCoordinates], minOccurrences, maxOccurrences, increment));
-    const leafletUrl = this.props.url || this.DEFAULT_URL;
-    const leafletAttribution = this.props.attribution || this.DEFAULT_ATTRIBUTION;
+    const coordinates = Object.keys(terms);
+    const markers = coordinates.map(aCoordinates => this._formatMarker(aCoordinates, terms[aCoordinates], minOccurrences, maxOccurrences, increment));
+    const leafletUrl = url || this.DEFAULT_URL;
+    const leafletAttribution = attribution || this.DEFAULT_ATTRIBUTION;
 
     return (
-      <Map center={this.position} zoom={this.state.zoomLevel} onZoomend={this._onZoomChange} style={{height: this.props.height, width: this.props.width}} scrollWheelZoom={false}>
-        <TileLayer url={leafletUrl}
-                   maxZoom={19}
-                   attribution={leafletAttribution}/>
+      <Map id={`visualization-${id}`} center={this.position} zoom={this.state.zoomLevel} onZoomend={this._onZoomChange} className={style.map}
+           style={{ height: height, width: width }} scrollWheelZoom={false} animate={interactive} whenReady={onRenderComplete}>
+        <TileLayer url={leafletUrl} maxZoom={19} attribution={leafletAttribution} />
         {markers}
       </Map>
     );

--- a/src/web/components/MapVisualization.jsx
+++ b/src/web/components/MapVisualization.jsx
@@ -16,6 +16,7 @@ const MapVisualization = React.createClass({
     attribution: PropTypes.string,
     interactive: PropTypes.bool,
     onRenderComplete: PropTypes.func,
+    locked: PropTypes.bool, // Disables zoom and dragging
   },
   getDefaultProps() {
     return {
@@ -24,6 +25,7 @@ const MapVisualization = React.createClass({
       attribution: '&copy; <a href="http://osm.org/copyright" target="_blank">OpenStreetMap</a> contributors',
       interactive: true,
       onRenderComplete: () => {},
+      locked: PropTypes.bool,
     };
   },
 
@@ -101,7 +103,7 @@ const MapVisualization = React.createClass({
   },
 
   render() {
-    const { data, id, height, width, url, attribution, interactive } = this.props;
+    const { data, id, height, width, url, attribution, interactive, locked } = this.props;
 
     const terms = data.terms;
     const occurrences = Object.keys(terms).map(k => terms[k]);
@@ -113,22 +115,25 @@ const MapVisualization = React.createClass({
     const markers = coordinates.map(aCoordinates => this._formatMarker(aCoordinates, terms[aCoordinates], minOccurrences, maxOccurrences, increment));
 
     return (
-      <Map ref={(c) => { this._map = c; }}
-           id={`visualization-${id}`}
-           center={this.position}
-           zoom={this.state.zoomLevel}
-           onZoomend={this._onZoomChange}
-           className={style.map}
-           style={{ height: height, width: width }}
-           scrollWheelZoom={false}
-           animate={interactive}
-           zoomAnimation={interactive}
-           fadeAnimation={interactive}
-           markerZoomAnimation={interactive}
-           whenReady={this._handleMapReady}>
-        <TileLayer url={url} maxZoom={19} attribution={attribution} onLoad={this._handleTilesReady} />
-        {markers}
-      </Map>
+      <div className={locked ? style.mapLocked : ''}>
+        {locked && <div className={style.overlay} style={{ height: height, width: width }} />}
+        <Map ref={(c) => { this._map = c; }}
+             id={`visualization-${id}`}
+             center={this.position}
+             zoom={this.state.zoomLevel}
+             onZoomend={this._onZoomChange}
+             className={style.map}
+             style={{ height: height, width: width }}
+             scrollWheelZoom={false}
+             animate={interactive}
+             zoomAnimation={interactive}
+             fadeAnimation={interactive}
+             markerZoomAnimation={interactive}
+             whenReady={this._handleMapReady}>
+          <TileLayer url={url} maxZoom={19} attribution={attribution} onLoad={this._handleTilesReady} />
+          {markers}
+        </Map>
+      </div>
     );
   },
 });

--- a/src/web/components/MapVisualization.jsx
+++ b/src/web/components/MapVisualization.jsx
@@ -61,8 +61,13 @@ const MapVisualization = React.createClass({
     const formattedCoordinates = coordinates.split(',').map(component => Number(component));
     const radius = this._getBucket(occurrences, this.MARKER_RADIUS_SIZES, min, max, increment);
     return (
-      <CircleMarker key={coordinates} center={formattedCoordinates} radius={radius} color="#AF2228" fillColor="#D3242B"
-                    weight={2} opacity={0.8}>
+      <CircleMarker key={coordinates}
+                    center={formattedCoordinates}
+                    radius={radius}
+                    color="#AF2228"
+                    fillColor="#D3242B"
+                    weight={2}
+                    opacity={0.8}>
         <Popup>
           <dl>
             <dt>Coordinates:</dt>

--- a/src/web/components/MapVisualization.jsx
+++ b/src/web/components/MapVisualization.jsx
@@ -1,7 +1,9 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Map, TileLayer, CircleMarker, Popup } from 'react-leaflet';
-import { Spinner } from 'components/common';
+
+import {} from 'leaflet/dist/leaflet.css';
+import style from './MapVisualization.css';
 
 const MapVisualization = React.createClass({
   propTypes: {
@@ -21,30 +23,12 @@ const MapVisualization = React.createClass({
   getInitialState() {
     return {
       zoomLevel: 1,
-      isComponentMounted: false, // Leaflet operates directly with the DOM, so we need to wait until it is ready :grumpy:
     };
   },
-  componentDidMount() {
-    this.leafletStyle.use();
-    this.style.use();
-    this._onComponentMount();
-  },
-
-  componentWillUnmount() {
-    this.leafletStyle.unuse();
-    this.style.unuse();
-  },
-
-  _onComponentMount() {
-    this.setState({isComponentMounted: true});
-  },
-
-  leafletStyle: require('!style/useable!css!leaflet/dist/leaflet.css'),
-  style: require('!style/useable!css!./MapVisualization.css'),
 
   position: [0, 0],
   DEFAULT_URL: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-  DEFAULT_ATTRIBUTION: `&copy; <a href="http://osm.org/copyright" target="_blank">OpenStreetMap</a> contributors`,
+  DEFAULT_ATTRIBUTION: '&copy; <a href="http://osm.org/copyright" target="_blank">OpenStreetMap</a> contributors',
   MARKER_RADIUS_SIZES: 10,
   MARKER_RADIUS_INCREMENT_SIZES: 10,
   // Coordinates are given as "lat,long"
@@ -76,9 +60,6 @@ const MapVisualization = React.createClass({
     return bucket + increment;
   },
   render() {
-    if (!this.state.isComponentMounted) {
-      return <Spinner/>;
-    }
 
     const data = this.props.data.terms;
     const occurrences = Object.keys(data).map((k) => data[k]);

--- a/src/web/components/MapVisualization.jsx
+++ b/src/web/components/MapVisualization.jsx
@@ -1,3 +1,4 @@
+/* eslint-env browser */
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Map, TileLayer, CircleMarker, Popup } from 'react-leaflet';
@@ -9,9 +10,8 @@ const MapVisualization = React.createClass({
   propTypes: {
     id: PropTypes.string.isRequired,
     data: PropTypes.object,
-    config: PropTypes.object.isRequired,
-    height: PropTypes.number,
-    width: PropTypes.number,
+    height: PropTypes.number.isRequired,
+    width: PropTypes.number.isRequired,
     url: PropTypes.string,
     attribution: PropTypes.string,
     interactive: PropTypes.bool,
@@ -20,10 +20,13 @@ const MapVisualization = React.createClass({
   getDefaultProps() {
     return {
       data: {},
+      url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+      attribution: '&copy; <a href="http://osm.org/copyright" target="_blank">OpenStreetMap</a> contributors',
       interactive: true,
       onRenderComplete: () => {},
     };
   },
+
   getInitialState() {
     return {
       zoomLevel: 1,
@@ -42,8 +45,6 @@ const MapVisualization = React.createClass({
 
   _map: undefined,
   position: [0, 0],
-  DEFAULT_URL: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-  DEFAULT_ATTRIBUTION: '&copy; <a href="http://osm.org/copyright" target="_blank">OpenStreetMap</a> contributors',
   MARKER_RADIUS_SIZES: 10,
   MARKER_RADIUS_INCREMENT_SIZES: 10,
 
@@ -60,14 +61,15 @@ const MapVisualization = React.createClass({
     const formattedCoordinates = coordinates.split(',').map(component => Number(component));
     const radius = this._getBucket(occurrences, this.MARKER_RADIUS_SIZES, min, max, increment);
     return (
-      <CircleMarker key={coordinates} center={formattedCoordinates} radius={radius} color="#AF2228" fillColor="#D3242B" weight={2} opacity={0.8}>
+      <CircleMarker key={coordinates} center={formattedCoordinates} radius={radius} color="#AF2228" fillColor="#D3242B"
+                    weight={2} opacity={0.8}>
         <Popup>
-            <dl>
-              <dt>Coordinates:</dt>
-              <dd>{coordinates}</dd>
-              <dt>Number of occurrences:</dt>
-              <dd>{occurrences}</dd>
-            </dl>
+          <dl>
+            <dt>Coordinates:</dt>
+            <dd>{coordinates}</dd>
+            <dt>Number of occurrences:</dt>
+            <dd>{occurrences}</dd>
+          </dl>
         </Popup>
       </CircleMarker>
     );
@@ -95,13 +97,19 @@ const MapVisualization = React.createClass({
 
     const coordinates = Object.keys(terms);
     const markers = coordinates.map(aCoordinates => this._formatMarker(aCoordinates, terms[aCoordinates], minOccurrences, maxOccurrences, increment));
-    const leafletUrl = url || this.DEFAULT_URL;
-    const leafletAttribution = attribution || this.DEFAULT_ATTRIBUTION;
 
     return (
-      <Map id={`visualization-${id}`} center={this.position} zoom={this.state.zoomLevel} onZoomend={this._onZoomChange} className={style.map}
-           style={{ height: height, width: width }} scrollWheelZoom={false} animate={interactive} whenReady={onRenderComplete}>
-        <TileLayer url={leafletUrl} maxZoom={19} attribution={leafletAttribution} />
+      <Map ref={(c) => { this._map = c; }}
+           id={`visualization-${id}`}
+           center={this.position}
+           zoom={this.state.zoomLevel}
+           onZoomend={this._onZoomChange}
+           className={style.map}
+           style={{ height: height, width: width }}
+           scrollWheelZoom={false}
+           animate={interactive}
+           whenReady={onRenderComplete}>
+        <TileLayer url={url} maxZoom={19} attribution={attribution} />
         {markers}
       </Map>
     );


### PR DESCRIPTION
This PR helps fixing some of the map visualization's quirks. A summary of the changes is:
- Updated `react-leaflet` and `leaflet` dependencies
- Fixed issues when resizing the map container, ensuring tiles are loaded afterwards and markers are in the right place
- Add styles to ensure map is looking good on media print
- Allow consumers to customize map interactivity
- Provide a callback to notify customers when the map is fully rendered