### PR TITLE
Overlay fixes

### DIFF
--- a/src/web/components/MapVisualization.css
+++ b/src/web/components/MapVisualization.css
@@ -1,6 +1,6 @@
 :local(.overlay) {
     position: absolute;
-    z-index: 1000;
+    z-index: 999; /* So it displays below bootstrap dropdowns */
 }
 
 :local(.mapLocked) .leaflet-control-container {

--- a/src/web/components/MapVisualization.jsx
+++ b/src/web/components/MapVisualization.jsx
@@ -25,7 +25,7 @@ const MapVisualization = React.createClass({
       attribution: '&copy; <a href="http://osm.org/copyright" target="_blank">OpenStreetMap</a> contributors',
       interactive: true,
       onRenderComplete: () => {},
-      locked: PropTypes.bool,
+      locked: false,
     };
   },
 


### PR DESCRIPTION
After the last PR there were issues adding a map to a dashboard, as the dropdown menu couldn't be clicked. This PR solves the problem by:

- Changing the map overlay `z-index`, ensuring it will be below bootstrap dropdowns
- Fixing default `locked` prop, making the map unlocked by default