### PR TITLE
use correct property for autovalue javabean extension

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>org.graylog.autovalue</groupId>
             <artifactId>auto-value-javabean</artifactId>
-            <version>${graylog.version}</version>
+            <version>${auto-value-javabean.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
otherwise the extension will not load because the old version refers to a non-existent class