### PR TITLE
Remove hot-module-replacement code

### DIFF
--- a/src/web/index.jsx
+++ b/src/web/index.jsx
@@ -47,7 +47,3 @@ const manifest = new PluginManifest(packageJson, {
 
 PluginStore.register(manifest);
 
-if (module.hot) {
-  module.hot.accept();
-  module.hot.dispose(() => PluginStore.unregister(manifest));
-}


### PR DESCRIPTION
We don't use HMR at the moment, remove code blocking webpack from refreshing the page when changes are made.

Refs https://github.com/Graylog2/graylog2-server/pull/4388