### PR TITLE
Add "coordinates" (lat,long) in multi-value result of MaxmindDataAdapter

### DIFF
--- a/src/main/java/org/graylog/plugins/map/geoip/MaxmindDataAdapter.java
+++ b/src/main/java/org/graylog/plugins/map/geoip/MaxmindDataAdapter.java
@@ -173,6 +173,7 @@ public class MaxmindDataAdapter extends LookupDataAdapter {
                         singleValue = null;
                     } else {
                         singleValue = location.getLatitude() + "," + location.getLongitude();
+                        map.put("coordinates", singleValue);
                     }
                     return LookupResult.multi(singleValue, map);
                 } catch (AddressNotFoundException nfe) {

--- a/src/test/java/org/graylog/plugins/map/geoip/MaxmindDataAdapterTest.java
+++ b/src/test/java/org/graylog/plugins/map/geoip/MaxmindDataAdapterTest.java
@@ -126,6 +126,16 @@ public class MaxmindDataAdapterTest {
         }
 
         @Test
+        public void doGetIncludesCoordinatesInMultiValueResult() {
+            // This test will possibly get flaky when the entry for 8.8.8.8 changes!
+            final LookupResult lookupResult = adapter.doGet("8.8.8.8");
+            assertThat(lookupResult.isEmpty()).isFalse();
+            assertThat(lookupResult.multiValue()).isNotEmpty();
+            assertThat(lookupResult.multiValue())
+                    .hasEntrySatisfying("coordinates", value -> assertThat((String) value).matches("[0-9.\\-]+,[0-9.\\-]+"));
+        }
+
+        @Test
         public void doGetReturnsResultIfCityResponseFieldsAreNull() throws Exception {
             final CityResponse cityResponse = new CityResponse(null, null, null, null, null, null, null, null, null, null);
             final DatabaseReader mockDatabaseReader = mock(DatabaseReader.class);


### PR DESCRIPTION
By including the coordinates (lat,long) in the multi-value result of `MaxmindDataAdapter`,
users can use the coordinate pair as data source for their Map widgets without having to
manually concatenate the string or look up the same IP address twice.

Examples:

```
let result = lookup("geo-ip-city", to_string($message.ip_address));

// Manually build the coordinate pair - ugly and error prone to swapping latitude and longitude.
let string_concat = concat(result.location.latitude, concat(",", result.location.longitude));

// Lookup single value result - bad performance due to unnecessary second lookup
let single_result = lookup_value("geo-ip-city", to_string($message.ip_address));

// Coordinates in multi-value result
let coordinates = result.coordinates;

set_field("ip_address_location", coordinates);
```