### PR TITLE
Fix potential NullPointerException in csv and maxmind data adapters

### DIFF
--- a/src/main/java/org/graylog/plugins/map/geoip/MaxmindDataAdapter.java
+++ b/src/main/java/org/graylog/plugins/map/geoip/MaxmindDataAdapter.java
@@ -49,7 +49,7 @@ public class MaxmindDataAdapter extends LookupDataAdapter {
     public static final String NAME = "maxmind_geoip";
     private final Config config;
     private final AtomicReference<DatabaseReader> databaseReader = new AtomicReference<>();
-    private FileInfo fileInfo;
+    private FileInfo fileInfo = FileInfo.empty();
 
     @Inject
     protected MaxmindDataAdapter(@Assisted("id") String id,


### PR DESCRIPTION
Make sure the "fileInfo" field is initialized with an empty FileInfo
object. Also catch all exceptions in FileInfo#forPath instead of
IOExceptions only.

Refs Graylog2/graylog2-server#4748

(cherry picked from commit Graylog2/graylog2-server@7759690fb241dd4e740724b36972237d96665dbc)